### PR TITLE
Load modules after core scripts

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,7 +12,6 @@ shared_scripts {
 }
 
 server_scripts {
-  'modules/_init.lua',
   '@oxmysql/lib/MySQL.lua',
   'core/mod_api.lua',
   'core/db.lua',
@@ -20,6 +19,7 @@ server_scripts {
   'core/audit.lua',
   'core/coalesce.lua',
   'core/save.lua',
+  'modules/_init.lua',
 
   'modules/**/shared/*.lua',
   'modules/**/server/*.lua',


### PR DESCRIPTION
## Summary
- ensure server modules initialize after core scripts by moving `modules/_init.lua` below core script registrations in `fxmanifest.lua`

## Testing
- `luacheck .` (fails: 971 warnings / 7 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a024cd0d688332b231e55f9441337f