### PR TITLE
fix(skill): use dot access for rank check

### DIFF
--- a/modules/vehicle_system/server/repair.lua
+++ b/modules/vehicle_system/server/repair.lua
@@ -11,7 +11,7 @@ end
 
 local function skillBonus(src)
   if not VEH_CFG.integration.skill or GetResourceState('skill') ~= 'started' then return 0 end
-  local rank = exports.skill and exports.skill:getRank and (exports.skill:getRank(src,'mechanic') or 0) or 0
+  local rank = exports.skill and exports.skill.getRank and (exports.skill:getRank(src,'mechanic') or 0) or 0
   -- สมมติ rank 0..3 คืน 0..0.15
   return math.min(0.15, 0.05*rank)
 end


### PR DESCRIPTION
## Summary
- fix check for skill rank by using dot access `exports.skill.getRank`
- keep method call `exports.skill:getRank` as-is

## Testing
- `luac -p modules/vehicle_system/server/repair.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a029c6c39c8332abb6d46bb5e50ef1