### PR TITLE
Fix weather server loop

### DIFF
--- a/modules/weather/server/main.lua
+++ b/modules/weather/server/main.lua
@@ -1,1 +1,13 @@
-local Co=require'core/coalesce'; CreateThread(function() if not WEATHER_CFG.enabled then return end local w={ name='EXTRASUNNY', wind=0.1, temp=28.0 } while true do Wait(WEATHER_CFG.interval_ms or 7000) -- modules can push per-player snapshots end end)
+local Co = require 'core/coalesce'
+
+CreateThread(function()
+  if not WEATHER_CFG.enabled then return end
+
+  local w = { name = 'EXTRASUNNY', wind = 0.1, temp = 28.0 }
+
+  while true do
+    Wait(WEATHER_CFG.interval_ms or 7000)
+    -- modules can push per-player snapshots
+    TriggerClientEvent('weather:ambient', -1, w)
+  end
+end)


### PR DESCRIPTION
## Summary
- close weather server loop and thread
- broadcast basic ambient snapshot periodically

## Testing
- `luacheck modules/weather/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a02b43dcb08332b962bc9e6992673b