### PR TITLE
Fix module require paths

### DIFF
--- a/modules/skill/server/api.lua
+++ b/modules/skill/server/api.lua
@@ -1,4 +1,4 @@
-local rules = require 'server/rules'
+local rules = require 'modules/skill/server/rules'
 local DB = require 'core/db'
 local Co = require 'core/coalesce'
 

--- a/modules/status_bridge/server/api.lua
+++ b/modules/status_bridge/server/api.lua
@@ -1,8 +1,8 @@
 local adapters = {
-  esx = require 'server/adapters/esx',
-  qb  = require 'server/adapters/qb',
-  ox  = require 'server/adapters/ox',
-  standalone = require 'server/adapters/standalone',
+  esx = require 'modules/status_bridge/server/adapters/esx',
+  qb  = require 'modules/status_bridge/server/adapters/qb',
+  ox  = require 'modules/status_bridge/server/adapters/ox',
+  standalone = require 'modules/status_bridge/server/adapters/standalone',
 }
 
 local activeAdapter = nil

--- a/modules/worldengine/server/api.lua
+++ b/modules/worldengine/server/api.lua
@@ -1,5 +1,5 @@
-local zones    = require 'server/zones'
-local res      = require 'server/resources'
+local zones    = require 'modules/worldengine/server/zones'
+local res      = require 'modules/worldengine/server/resources'
 
 WorldAPI = {}
 

--- a/modules/worldengine/server/main.lua
+++ b/modules/worldengine/server/main.lua
@@ -1,5 +1,5 @@
-local zones = require 'server/zones'
-local res   = require 'server/resources'
+local zones = require 'modules/worldengine/server/zones'
+local res   = require 'modules/worldengine/server/resources'
 
 CreateThread(function()
   if not WORLD_CFG.enabled then return end


### PR DESCRIPTION
## Summary
- fix Skill module rules require path
- update Status Bridge adapter paths
- update WorldEngine require paths for zones/resources

## Testing
- `fxserver` *(fails: command not found)*
- `apt-get install -y fxserver` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a0313cdb64833295771f672d7f5273