### PR TITLE
Load worldengine config via shared scripts

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,7 +8,8 @@ lua54 'yes'
 
 shared_scripts {
   '@ox_lib/init.lua',
-  'core/config.lua'
+  'core/config.lua',
+  'modules/**/shared/*.lua'
 }
 
 server_scripts {
@@ -20,8 +21,6 @@ server_scripts {
   'core/coalesce.lua',
   'core/save.lua',
   'modules/_init.lua',
-
-  'modules/**/shared/*.lua',
   'modules/**/server/*.lua',
 }
 
@@ -29,8 +28,6 @@ client_scripts {
   'core/mod_client.lua',
   'core/devpanel.lua',
   'core/client_coalesced.lua',
-
-  'modules/**/shared/*.lua',
   'modules/**/client/*.lua'
 }
 

--- a/modules/worldengine/shared/config.lua
+++ b/modules/worldengine/shared/config.lua
@@ -28,13 +28,13 @@ WORLD_CFG = {
     }
   },
 
-  -- Resources / Looting
+  -- Resources / Looting (consumed by server/resources.lua)
   resources = {
-    limits = {
-      per_player_per_min = 5,
-      per_node_cooldown_s = 50,
-      per_container_lock_s = 10
-    },
+      limits = {
+        per_player_per_min = 5,  -- resource_limit
+        per_node_cooldown_s = 50,
+        per_container_lock_s = 10
+      },
     nodes = {
       mining  = { tools={'pickaxe'},  respawn_min=15*60, respawn_max=45*60, stamina_cost=6 },
       woodcut = { tools={'hatchet'},  respawn_min=10*60, respawn_max=30*60, stamina_cost=5 },
@@ -76,3 +76,4 @@ WORLD_CFG = {
     max_interact_dist = 2.2,
   }
 }
+


### PR DESCRIPTION
## Summary
- Include module shared scripts (including worldengine config) in `shared_scripts` to ensure availability without duplication
- Document resource limits and respawn settings in worldengine config

## Testing
- `luac -p fxmanifest.lua modules/worldengine/shared/config.lua modules/worldengine/server/resources.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a033b324fc83328fd847b16eebd802