### PR TITLE
style: keep medical treatment lines together

### DIFF
--- a/modules/medical/shared/tables.lua
+++ b/modules/medical/shared/tables.lua
@@ -7,7 +7,7 @@ Treatment = {
   splint    = { needs = { item='splint',   count=1 }, effect = function(st,w) if w.kind=='fracture' then w.sev=1 end end },
   disinfect = { needs = { item='disinfect',count=1 }, effect = function(st,w) w.dirty=false end },
   painkiller= { needs = { item='painkiller',count=1 }, effect = function(st) st.fx.pain=math.max(0, st.fx.pain-25) end },
-  antibiotic= { needs = { item='antibiotic',count=1 }, effect = function(st) for _,s in ipairs(st.sick) do s.until = GetGameTimer() + 60*1000 end end },
-  salineIV  = { needs = { item='saline',  count=1 }, effect = function(st) st.blood.volume = math.min(100, st.blood.volume + 15) end },
-  bloodIV   = { needs = { item='bloodbag',count=1 }, effect = function(st) st.blood.volume = math.min(100, st.blood.volume + 30) end },
+  antibiotic = { needs = { item='antibiotic',count=1 }, effect = function(st) for _,s in ipairs(st.sick) do s.until = GetGameTimer() + 60*1000 end end },
+  salineIV   = { needs = { item='saline',  count=1 }, effect = function(st) st.blood.volume = math.min(100, st.blood.volume + 15) end },
+  bloodIV    = { needs = { item='bloodbag',count=1 }, effect = function(st) st.blood.volume = math.min(100, st.blood.volume + 30) end },
 }


### PR DESCRIPTION
## Summary
- keep `antibiotic`, `salineIV`, and `bloodIV` treatment definitions on single lines
- retain closing `end },` for medical treatments

## Testing
- `luac -p modules/medical/shared/tables.lua` *(fails: `<name> expected near 'until'`)*

------
https://chatgpt.com/codex/tasks/task_e_68a036d6842483329392227c438897db