### PR TITLE
fix: correct pipeline require path

### DIFF
--- a/modules/medical/server/main.lua
+++ b/modules/medical/server/main.lua
@@ -1,4 +1,4 @@
-local P = require 'server/pipeline'
+local P = require 'modules/medical/server/pipeline'
 local Co = require 'core/coalesce'
 
 CreateThread(function()


### PR DESCRIPTION
## Summary
- fix medical server script to require pipeline via its module path

## Testing
- `luac5.1 -p modules/medical/server/main.lua`
- `lua -e "package.path = './?.lua;./?/init.lua;' .. package.path; MED_CFG={enabled=false,tick={idle_ms=0,event_ms=0}}; CreateThread=function(fn) end; GetPlayers=function() return {} end; require('modules.medical.server.main'); print('main loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_68a0389ed0548332a5904b0f286aeab5