### PR TITLE
fix: correct ox inventory usable item export

### DIFF
--- a/modules/status_bridge/server/adapter_esx.lua
+++ b/modules/status_bridge/server/adapter_esx.lua
@@ -12,7 +12,7 @@ end
 
 local function onUseItem(name, cb)
   if GetResourceState('ox_inventory') == 'started' then
-    exports.ox_inventory:registerUsableItem(name, function(src, item, data)
+    exports.ox_inventory:RegisterUsableItem(name, function(src, item, data)
       local ok, err = pcall(cb, src, item, data)
       if not ok then print('[SB][useitem] error:', err) end
     end)


### PR DESCRIPTION
## Summary
- use RegisterUsableItem export from ox_inventory in status bridge

## Testing
- `lua - <<'EOF' ... EOF`
- `luac -p modules/status_bridge/server/adapter_esx.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a039f3c08c83329ba810cded849fb9