### PR TITLE
refactor: rename sickness expiry field

### DIFF
--- a/modules/medical/shared/tables.lua
+++ b/modules/medical/shared/tables.lua
@@ -7,7 +7,7 @@ Treatment = {
   splint    = { needs = { item='splint',   count=1 }, effect = function(st,w) if w.kind=='fracture' then w.sev=1 end end },
   disinfect = { needs = { item='disinfect',count=1 }, effect = function(st,w) w.dirty=false end },
   painkiller= { needs = { item='painkiller',count=1 }, effect = function(st) st.fx.pain=math.max(0, st.fx.pain-25) end },
-  antibiotic = { needs = { item='antibiotic',count=1 }, effect = function(st) for _,s in ipairs(st.sick) do s.until = GetGameTimer() + 60*1000 end end },
+  antibiotic = { needs = { item='antibiotic',count=1 }, effect = function(st) for _,s in ipairs(st.sick) do s.expires = GetGameTimer() + 60*1000 end end },
   salineIV   = { needs = { item='saline',  count=1 }, effect = function(st) st.blood.volume = math.min(100, st.blood.volume + 15) end },
   bloodIV    = { needs = { item='bloodbag',count=1 }, effect = function(st) st.blood.volume = math.min(100, st.blood.volume + 30) end },
 }

--- a/modules/medical/shared/types.lua
+++ b/modules/medical/shared/types.lua
@@ -1,5 +1,5 @@
 ---@class Wound { kind: 'cut'|'bruise'|'fracture'|'burn', sev: 1|2|3, bleeding: boolean, dirty: boolean }
----@class Sickness { key: 'flu'|'food'|'cholera', until: number }
+---@class Sickness { key: 'flu'|'food'|'cholera', expires: number }
 ---@class Effects { pain:number, shock:number, fever:number, buffs:table<string,number> }
 
 ---@class MedState


### PR DESCRIPTION
## Summary
- rename Sickness.until to expires
- update antibiotic treatment to use expires field

## Testing
- `luacheck modules/medical/shared/tables.lua modules/medical/shared/types.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a03cb38b048332bd3c8cf471d816de