### PR TITLE
fix: continue ox inventory item processing

### DIFF
--- a/modules/status_bridge/server/adapter_esx.lua
+++ b/modules/status_bridge/server/adapter_esx.lua
@@ -13,20 +13,30 @@ end
 local function onUseItem(name, cb)
   if GetResourceState('ox_inventory') == 'started' then
     local ox = exports.ox_inventory
-    local register = ox and (ox.RegisterUseableItem or ox.RegisterUsableItem or ox.CreateUseableItem or ox.CreateUsableItem)
-    if register then
-      register(ox, name, function(a, b, c)
-        local src, item, data
-        if type(a) == 'table' then
-          data = a
-          src = a.source or a.playerId
-          item = a.item or b
-        else
-          src, item, data = a, b, c
-        end
-        local ok, err = pcall(cb, src, item, data)
+    if ox and ox.registerHook then
+      ox.registerHook('useItem', function(payload, cont)
+        local src = payload.source or payload.playerId
+        local item = payload.item or payload.name
+        local ok, err = pcall(cb, src, item, payload)
         if not ok then print('[SB][useitem] error:', err) end
-      end)
+        if cont then cont(true) end
+      end, { itemFilter = { name } })
+    else
+      local register = ox and (ox.RegisterUseableItem or ox.RegisterUsableItem or ox.CreateUseableItem or ox.CreateUsableItem)
+      if register then
+        register(ox, name, function(a, b, c)
+          local src, item, data
+          if type(a) == 'table' then
+            data = a
+            src = a.source or a.playerId
+            item = a.item or b
+          else
+            src, item, data = a, b, c
+          end
+          local ok, err = pcall(cb, src, item, data)
+          if not ok then print('[SB][useitem] error:', err) end
+        end)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- ensure ox_inventory continues processing items registered via registerHook

## Testing
- `luac -p modules/status_bridge/server/adapter_esx.lua`
- `luacheck modules/status_bridge/server/adapter_esx.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0443f5b5c8332b72a11e4a924bf3a